### PR TITLE
test/test2.ijs D. deprecated; change to pderiv

### DIFF
--- a/test/test2.ijs
+++ b/test/test2.ijs
@@ -1,4 +1,5 @@
 load 'math/lbfgs'
+load 'math/calculus'
 cocurrent 'base'
 
 NB. =========================================================
@@ -6,7 +7,7 @@ test=: 3 : 0
 'N M'=. 4 5           NB. dimension of X, number of corrections
 f=. +/@:*:@:-&3 _2002 800 1 NB. example sum of squares  function
 
-Df=. f D. 1           NB. exact derivative
+NB. Df=. f D. 1       NB. D. deprecated
 h=. 1.0e_8            NB. h for numerical derivative
 H=. (h&*)@=@i.@#      NB. diag h
 
@@ -19,7 +20,8 @@ W=. ((N*(>:+:M))++:M)$2.2-2.2  NB. real work vector
 X=. N$400.2-2.2      NB. initialize X
 iter=. 0             NB. initialize iter
 whilst. (IFLAG>0)*.(iter<:2000) do. iter=. >:iter
-  'F G'=. (f;Df) X   NB. funtion and derivative value -- use Df for numerical derivative
+  F=. f X   NB. funtion value
+  G=. f pderiv_jcalculus_ 1 X  NB. derivative value -- numerical derivative
   'N M X F G DIAGCO DIAG IPRINT EPS XTOL W IFLAG'=. r=. }. lbfgs ,.&.> (N;M;X;F;G;DIAGCO;DIAG;IPRINT;EPS;XTOL;W;IFLAG)
 end.
 iter;(f;])X


### PR DESCRIPTION
D. deprecated since J 9.01, changed to pderiv_jcalculus_ from 'math/calculus'.
Did not consider the legacy version.